### PR TITLE
Implement campaign management features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # MyMI Media Repo
+
+This repository manages marketing campaign files used by the MyMI Wallet system.
+
+## Symlink Setup
+
+To allow MyMI Wallet to access campaign files, create a symlink from the
+`writable/MyMI-Media/Campaigns/` directory in this repo to the server directory
+`/var/www/MyMI-Media/Campaigns`:
+
+```bash
+scripts/setup_symlink.sh
+```
+
+The script creates the target directory and links it to this repo's writable
+folder so that new campaign content can be scanned automatically.
+
+## Approval Workflow
+
+1. Run the `campaigns:scan` command (scheduled daily via cron) to import new
+   campaign files into the `campaign_files` table.
+2. Visit `/admin/campaigns` to review pending files.
+3. Approve or reject each file. Approved files are sent to a Zapier webhook,
+   which handles email distribution or blog posting.
+
+Configure the Zapier webhook URL in your environment file under
+`zapier.webhook`.

--- a/app/Commands/CampaignScanner.php
+++ b/app/Commands/CampaignScanner.php
@@ -1,0 +1,44 @@
+<?php
+namespace App\Commands;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+use App\Models\CampaignFileModel;
+
+class CampaignScanner extends BaseCommand
+{
+    protected $group       = 'Campaigns';
+    protected $name        = 'campaigns:scan';
+    protected $description = 'Scans campaign directories and imports files.';
+
+    public function run(array $params)
+    {
+        $path = '/var/www/MyMI-Media/Campaigns';
+        if (!is_dir($path)) {
+            CLI::error("Campaign directory not found: {$path}");
+            return;
+        }
+
+        $model = new CampaignFileModel();
+        $dirs  = glob($path . '/*', GLOB_ONLYDIR);
+
+        foreach ($dirs as $dir) {
+            $slug = basename($dir);
+            $files = ['blog-draft', 'email-drip'];
+            foreach ($files as $file) {
+                $filePath = "$dir/{$file}.txt";
+                if (is_file($filePath)) {
+                    $existing = $model->where('slug', $slug)->where('path', $filePath)->first();
+                    if (!$existing) {
+                        $model->insert([
+                            'slug'  => $slug,
+                            'path'  => $filePath,
+                            'status'=> 'pending',
+                        ]);
+                        CLI::write("Imported {$filePath}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -1,0 +1,6 @@
+<?php
+$routes->group('admin', function($routes) {
+    $routes->get('campaigns', 'CampaignReviewController::index');
+    $routes->get('campaigns/approve/(:num)', 'CampaignReviewController::approve/$1');
+    $routes->get('campaigns/reject/(:num)', 'CampaignReviewController::reject/$1');
+});

--- a/app/Controllers/CampaignReviewController.php
+++ b/app/Controllers/CampaignReviewController.php
@@ -1,0 +1,39 @@
+<?php
+namespace App\Controllers;
+
+use App\Models\CampaignFileModel;
+use App\Services\ZapierService;
+use CodeIgniter\HTTP\ResponseInterface;
+
+class CampaignReviewController extends BaseController
+{
+    public function index()
+    {
+        $model = new CampaignFileModel();
+        $data['files'] = $model->where('status', 'pending')->findAll();
+        return view('campaigns/pending', $data);
+    }
+
+    public function approve($id)
+    {
+        $model = new CampaignFileModel();
+        $file  = $model->find($id);
+        if (!$file) {
+            return redirect()->back()->with('error', 'File not found');
+        }
+        $model->update($id, ['status' => 'approved']);
+
+        $zapier = new ZapierService();
+        $zapier->sendCampaign($file);
+        return redirect()->back()->with('message', 'File approved');
+    }
+
+    public function reject($id)
+    {
+        $model = new CampaignFileModel();
+        if ($model->find($id)) {
+            $model->update($id, ['status' => 'rejected']);
+        }
+        return redirect()->back()->with('message', 'File rejected');
+    }
+}

--- a/app/Database/Migrations/2025-01-01-AddCampaignFiles.php
+++ b/app/Database/Migrations/2025-01-01-AddCampaignFiles.php
@@ -1,0 +1,26 @@
+<?php
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AddCampaignFiles extends Migration
+{
+    public function up()
+    {
+        $this->forge->addField([
+            'id'         => ['type' => 'INT', 'constraint' => 11, 'unsigned' => true, 'auto_increment' => true],
+            'slug'       => ['type' => 'VARCHAR', 'constraint' => 191],
+            'path'       => ['type' => 'VARCHAR', 'constraint' => 255],
+            'status'     => ['type' => 'ENUM("pending","approved","rejected")', 'default' => 'pending'],
+            'created_at' => ['type' => 'DATETIME', 'null' => true],
+            'updated_at' => ['type' => 'DATETIME', 'null' => true],
+        ]);
+        $this->forge->addKey('id', true);
+        $this->forge->createTable('campaign_files');
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('campaign_files');
+    }
+}

--- a/app/Entities/CampaignFile.php
+++ b/app/Entities/CampaignFile.php
@@ -1,0 +1,9 @@
+<?php
+namespace App\Entities;
+
+use CodeIgniter\Entity\Entity;
+
+class CampaignFile extends Entity
+{
+    protected $dates = ['created_at', 'updated_at'];
+}

--- a/app/Models/CampaignFileModel.php
+++ b/app/Models/CampaignFileModel.php
@@ -1,0 +1,13 @@
+<?php
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+class CampaignFileModel extends Model
+{
+    protected $table      = 'campaign_files';
+    protected $primaryKey = 'id';
+    protected $allowedFields = ['slug', 'path', 'status', 'created_at', 'updated_at'];
+    protected $useTimestamps = true;
+    protected $returnType    = \App\Entities\CampaignFile::class;
+}

--- a/app/Services/ZapierService.php
+++ b/app/Services/ZapierService.php
@@ -1,0 +1,26 @@
+<?php
+namespace App\Services;
+
+use CodeIgniter\HTTP\CURLRequest;
+use Config\Services;
+
+class ZapierService
+{
+    protected $webhookUrl;
+
+    public function __construct()
+    {
+        $this->webhookUrl = getenv('zapier.webhook');
+    }
+
+    public function sendCampaign($file)
+    {
+        $curl = Services::curlrequest();
+        $payload = [
+            'slug' => $file->slug,
+            'path' => $file->path,
+            'content' => file_exists($file->path) ? file_get_contents($file->path) : '',
+        ];
+        $curl->post($this->webhookUrl, $payload);
+    }
+}

--- a/app/Views/campaigns/pending.php
+++ b/app/Views/campaigns/pending.php
@@ -1,0 +1,25 @@
+<h1>Pending Campaign Files</h1>
+<?php if (session('message')): ?>
+<p><?= session('message') ?></p>
+<?php endif; ?>
+<table>
+    <thead>
+        <tr>
+            <th>Slug</th>
+            <th>Path</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($files as $file): ?>
+        <tr>
+            <td><?= esc($file->slug) ?></td>
+            <td><?= esc($file->path) ?></td>
+            <td>
+                <a href="<?= site_url('admin/campaigns/approve/'.$file->id) ?>">Approve</a>
+                <a href="<?= site_url('admin/campaigns/reject/'.$file->id) ?>">Reject</a>
+            </td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>

--- a/scripts/setup_symlink.sh
+++ b/scripts/setup_symlink.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Setup symlink for MyMI-Media campaigns within MyMI-Wallet
+
+# Directory where MyMI Wallet expects campaign folders
+TARGET_DIR="/var/www/MyMI-Media/Campaigns"
+# Local repository campaigns directory
+SOURCE_DIR="$(dirname "$(realpath "$0")")/../writable/MyMI-Media/Campaigns"
+
+# Create target directory if it doesn't exist
+sudo mkdir -p "$TARGET_DIR"
+
+# Create parent folder for source if missing
+mkdir -p "$SOURCE_DIR"
+
+# Create symlink
+if [ ! -L "$TARGET_DIR" ]; then
+    sudo ln -s "$SOURCE_DIR" "$TARGET_DIR"
+    echo "Symlink created from $SOURCE_DIR to $TARGET_DIR"
+else
+    echo "Symlink already exists: $TARGET_DIR"
+fi


### PR DESCRIPTION
## Summary
- add script to symlink campaign directory
- create migration for campaign_files table
- add model and entity for campaign files
- implement CampaignScanner CLI command
- add admin routes and controller with pending view
- integrate Zapier service
- document workflow

## Testing
- `php -v`
- `find app -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_687d7395f2c883259156dc9e29f73776