### PR TITLE
Add marketing content for new headlines

### DIFF
--- a/writable/MyMI-Media/Campaigns/Alphabet-Boosts-2025-Capex-Plans-By-10B-To-85B-As-AI-Era-Rolls-On/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Alphabet-Boosts-2025-Capex-Plans-By-10B-To-85B-As-AI-Era-Rolls-On/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Alphabet-Boosts-2025-Capex-Plans-By-10B-To-85B-As-AI-Era-Rolls-On/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Alphabet-Boosts-2025-Capex-Plans-By-10B-To-85B-As-AI-Era-Rolls-On/blog-draft.md
@@ -1,0 +1,5 @@
+# Alphabet boosts 2025 capex plans by $10B to $85B — as AI era rolls on
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Alphabet-Boosts-2025-Capex-Plans-By-10B-To-85B-As-AI-Era-Rolls-On/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Alphabet-Boosts-2025-Capex-Plans-By-10B-To-85B-As-AI-Era-Rolls-On/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Alphabet boosts 2025 capex plans by $10B to $85B — as AI era
+
+Hello,
+
+Alphabet boosts 2025 capex plans by $10B to $85B — as AI era rolls on Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Alphabet-Boosts-2025-Capex-Plans-By-10B-To-85B-As-AI-Era-Rolls-On/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Alphabet-Boosts-2025-Capex-Plans-By-10B-To-85B-As-AI-Era-Rolls-On/social-post.md
@@ -1,0 +1,1 @@
+Alphabet boosts 2025 capex plans by $10B to $85B — as AI era rolls on Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Alphabet-Boosts-2025-Capex-Plans-By-10B-To-85B-As-AI-Era-Rolls-On/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Alphabet-Boosts-2025-Capex-Plans-By-10B-To-85B-As-AI-Era-Rolls-On/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Alphabet boosts 2025 capex plans by $10B to $85B — as AI era rolls on"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Alphabet-Boosts-2025-Capex-Plans-By-10B-To-85B-As-AI-Era-Rolls-On/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Alphabet-Boosts-2025-Capex-Plans-By-10B-To-85B-As-AI-Era-Rolls-On/voiceover.md
@@ -1,0 +1,1 @@
+"Alphabet boosts 2025 capex plans by $10B to $85B — as AI era rolls on Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Alphabets-Stock-Falls-As-Earnings-Beat-Fails-To-Impress-Follow-Live-Coverage/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Alphabets-Stock-Falls-As-Earnings-Beat-Fails-To-Impress-Follow-Live-Coverage/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Alphabets-Stock-Falls-As-Earnings-Beat-Fails-To-Impress-Follow-Live-Coverage/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Alphabets-Stock-Falls-As-Earnings-Beat-Fails-To-Impress-Follow-Live-Coverage/blog-draft.md
@@ -1,0 +1,5 @@
+# Alphabet’s stock falls as earnings beat fails to impress — follow live coverage
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Alphabets-Stock-Falls-As-Earnings-Beat-Fails-To-Impress-Follow-Live-Coverage/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Alphabets-Stock-Falls-As-Earnings-Beat-Fails-To-Impress-Follow-Live-Coverage/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Alphabet’s stock falls as earnings beat fails to impress — f
+
+Hello,
+
+Alphabet’s stock falls as earnings beat fails to impress — follow live coverage Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Alphabets-Stock-Falls-As-Earnings-Beat-Fails-To-Impress-Follow-Live-Coverage/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Alphabets-Stock-Falls-As-Earnings-Beat-Fails-To-Impress-Follow-Live-Coverage/social-post.md
@@ -1,0 +1,1 @@
+Alphabet’s stock falls as earnings beat fails to impress — follow live coverage Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Alphabets-Stock-Falls-As-Earnings-Beat-Fails-To-Impress-Follow-Live-Coverage/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Alphabets-Stock-Falls-As-Earnings-Beat-Fails-To-Impress-Follow-Live-Coverage/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Alphabet’s stock falls as earnings beat fails to impress — follow live coverage"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Alphabets-Stock-Falls-As-Earnings-Beat-Fails-To-Impress-Follow-Live-Coverage/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Alphabets-Stock-Falls-As-Earnings-Beat-Fails-To-Impress-Follow-Live-Coverage/voiceover.md
@@ -1,0 +1,1 @@
+"Alphabet’s stock falls as earnings beat fails to impress — follow live coverage Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/American-Exceptionalism-Isnt-Dead-Foreign-Investor-Flows-Into-US-Show/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/American-Exceptionalism-Isnt-Dead-Foreign-Investor-Flows-Into-US-Show/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/American-Exceptionalism-Isnt-Dead-Foreign-Investor-Flows-Into-US-Show/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/American-Exceptionalism-Isnt-Dead-Foreign-Investor-Flows-Into-US-Show/blog-draft.md
@@ -1,0 +1,5 @@
+# ‘American exceptionalism’ isn’t dead, foreign investor flows into U.S. show
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/American-Exceptionalism-Isnt-Dead-Foreign-Investor-Flows-Into-US-Show/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/American-Exceptionalism-Isnt-Dead-Foreign-Investor-Flows-Into-US-Show/email-drip.md
@@ -1,0 +1,8 @@
+Subject: ‘American exceptionalism’ isn’t dead, foreign investor flows
+
+Hello,
+
+‘American exceptionalism’ isn’t dead, foreign investor flows into U.S. show Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/American-Exceptionalism-Isnt-Dead-Foreign-Investor-Flows-Into-US-Show/social-post.md
+++ b/writable/MyMI-Media/Campaigns/American-Exceptionalism-Isnt-Dead-Foreign-Investor-Flows-Into-US-Show/social-post.md
@@ -1,0 +1,1 @@
+‘American exceptionalism’ isn’t dead, foreign investor flows into U.S. show Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/American-Exceptionalism-Isnt-Dead-Foreign-Investor-Flows-Into-US-Show/video-script.md
+++ b/writable/MyMI-Media/Campaigns/American-Exceptionalism-Isnt-Dead-Foreign-Investor-Flows-Into-US-Show/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "‘American exceptionalism’ isn’t dead, foreign investor flows into U.S. show"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/American-Exceptionalism-Isnt-Dead-Foreign-Investor-Flows-Into-US-Show/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/American-Exceptionalism-Isnt-Dead-Foreign-Investor-Flows-Into-US-Show/voiceover.md
@@ -1,0 +1,1 @@
+"‘American exceptionalism’ isn’t dead, foreign investor flows into U.S. show Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/As-Oracles-Stock-Falls-After-Stargate-News-Heres-A-Big-Question-For-Investors/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/As-Oracles-Stock-Falls-After-Stargate-News-Heres-A-Big-Question-For-Investors/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/As-Oracles-Stock-Falls-After-Stargate-News-Heres-A-Big-Question-For-Investors/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/As-Oracles-Stock-Falls-After-Stargate-News-Heres-A-Big-Question-For-Investors/blog-draft.md
@@ -1,0 +1,5 @@
+# As Oracle’s stock falls after Stargate news, here’s a big question for investors
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/As-Oracles-Stock-Falls-After-Stargate-News-Heres-A-Big-Question-For-Investors/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/As-Oracles-Stock-Falls-After-Stargate-News-Heres-A-Big-Question-For-Investors/email-drip.md
@@ -1,0 +1,8 @@
+Subject: As Oracle’s stock falls after Stargate news, here’s a big qu
+
+Hello,
+
+As Oracle’s stock falls after Stargate news, here’s a big question for investors Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/As-Oracles-Stock-Falls-After-Stargate-News-Heres-A-Big-Question-For-Investors/social-post.md
+++ b/writable/MyMI-Media/Campaigns/As-Oracles-Stock-Falls-After-Stargate-News-Heres-A-Big-Question-For-Investors/social-post.md
@@ -1,0 +1,1 @@
+As Oracle’s stock falls after Stargate news, here’s a big question for investors Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/As-Oracles-Stock-Falls-After-Stargate-News-Heres-A-Big-Question-For-Investors/video-script.md
+++ b/writable/MyMI-Media/Campaigns/As-Oracles-Stock-Falls-After-Stargate-News-Heres-A-Big-Question-For-Investors/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "As Oracle’s stock falls after Stargate news, here’s a big question for investors"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/As-Oracles-Stock-Falls-After-Stargate-News-Heres-A-Big-Question-For-Investors/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/As-Oracles-Stock-Falls-After-Stargate-News-Heres-A-Big-Question-For-Investors/voiceover.md
@@ -1,0 +1,1 @@
+"As Oracle’s stock falls after Stargate news, here’s a big question for investors Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/As-Tesla-Shares-Slide-Why-Analysts-Are-Upbeat-On-Earnings-But-Investors-Arent/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/As-Tesla-Shares-Slide-Why-Analysts-Are-Upbeat-On-Earnings-But-Investors-Arent/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/As-Tesla-Shares-Slide-Why-Analysts-Are-Upbeat-On-Earnings-But-Investors-Arent/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/As-Tesla-Shares-Slide-Why-Analysts-Are-Upbeat-On-Earnings-But-Investors-Arent/blog-draft.md
@@ -1,0 +1,5 @@
+# As Tesla shares slide, why analysts are upbeat on earnings but investors aren’t
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/As-Tesla-Shares-Slide-Why-Analysts-Are-Upbeat-On-Earnings-But-Investors-Arent/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/As-Tesla-Shares-Slide-Why-Analysts-Are-Upbeat-On-Earnings-But-Investors-Arent/email-drip.md
@@ -1,0 +1,8 @@
+Subject: As Tesla shares slide, why analysts are upbeat on earnings b
+
+Hello,
+
+As Tesla shares slide, why analysts are upbeat on earnings but investors aren’t Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/As-Tesla-Shares-Slide-Why-Analysts-Are-Upbeat-On-Earnings-But-Investors-Arent/social-post.md
+++ b/writable/MyMI-Media/Campaigns/As-Tesla-Shares-Slide-Why-Analysts-Are-Upbeat-On-Earnings-But-Investors-Arent/social-post.md
@@ -1,0 +1,1 @@
+As Tesla shares slide, why analysts are upbeat on earnings but investors aren’t Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/As-Tesla-Shares-Slide-Why-Analysts-Are-Upbeat-On-Earnings-But-Investors-Arent/video-script.md
+++ b/writable/MyMI-Media/Campaigns/As-Tesla-Shares-Slide-Why-Analysts-Are-Upbeat-On-Earnings-But-Investors-Arent/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "As Tesla shares slide, why analysts are upbeat on earnings but investors aren’t"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/As-Tesla-Shares-Slide-Why-Analysts-Are-Upbeat-On-Earnings-But-Investors-Arent/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/As-Tesla-Shares-Slide-Why-Analysts-Are-Upbeat-On-Earnings-But-Investors-Arent/voiceover.md
@@ -1,0 +1,1 @@
+"As Tesla shares slide, why analysts are upbeat on earnings but investors aren’t Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/As-The-Latest-Memestock-Drama-Unfolds-One-Thing-Is-Different-This-Time-Around/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/As-The-Latest-Memestock-Drama-Unfolds-One-Thing-Is-Different-This-Time-Around/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/As-The-Latest-Memestock-Drama-Unfolds-One-Thing-Is-Different-This-Time-Around/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/As-The-Latest-Memestock-Drama-Unfolds-One-Thing-Is-Different-This-Time-Around/blog-draft.md
@@ -1,0 +1,5 @@
+# As the latest meme-stock drama unfolds, one thing is different this time around
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/As-The-Latest-Memestock-Drama-Unfolds-One-Thing-Is-Different-This-Time-Around/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/As-The-Latest-Memestock-Drama-Unfolds-One-Thing-Is-Different-This-Time-Around/email-drip.md
@@ -1,0 +1,8 @@
+Subject: As the latest meme-stock drama unfolds, one thing is differe
+
+Hello,
+
+As the latest meme-stock drama unfolds, one thing is different this time around Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/As-The-Latest-Memestock-Drama-Unfolds-One-Thing-Is-Different-This-Time-Around/social-post.md
+++ b/writable/MyMI-Media/Campaigns/As-The-Latest-Memestock-Drama-Unfolds-One-Thing-Is-Different-This-Time-Around/social-post.md
@@ -1,0 +1,1 @@
+As the latest meme-stock drama unfolds, one thing is different this time around Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/As-The-Latest-Memestock-Drama-Unfolds-One-Thing-Is-Different-This-Time-Around/video-script.md
+++ b/writable/MyMI-Media/Campaigns/As-The-Latest-Memestock-Drama-Unfolds-One-Thing-Is-Different-This-Time-Around/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "As the latest meme-stock drama unfolds, one thing is different this time around"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/As-The-Latest-Memestock-Drama-Unfolds-One-Thing-Is-Different-This-Time-Around/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/As-The-Latest-Memestock-Drama-Unfolds-One-Thing-Is-Different-This-Time-Around/voiceover.md
@@ -1,0 +1,1 @@
+"As the latest meme-stock drama unfolds, one thing is different this time around Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/As-Trump-Unveils-AI-Action-Plan-Where-It-Works-And-Where-It-Falls-Short/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/As-Trump-Unveils-AI-Action-Plan-Where-It-Works-And-Where-It-Falls-Short/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/As-Trump-Unveils-AI-Action-Plan-Where-It-Works-And-Where-It-Falls-Short/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/As-Trump-Unveils-AI-Action-Plan-Where-It-Works-And-Where-It-Falls-Short/blog-draft.md
@@ -1,0 +1,5 @@
+# As Trump unveils AI ‘action plan,’ where it works and where it falls short
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/As-Trump-Unveils-AI-Action-Plan-Where-It-Works-And-Where-It-Falls-Short/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/As-Trump-Unveils-AI-Action-Plan-Where-It-Works-And-Where-It-Falls-Short/email-drip.md
@@ -1,0 +1,8 @@
+Subject: As Trump unveils AI ‘action plan,’ where it works and where 
+
+Hello,
+
+As Trump unveils AI ‘action plan,’ where it works and where it falls short Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/As-Trump-Unveils-AI-Action-Plan-Where-It-Works-And-Where-It-Falls-Short/social-post.md
+++ b/writable/MyMI-Media/Campaigns/As-Trump-Unveils-AI-Action-Plan-Where-It-Works-And-Where-It-Falls-Short/social-post.md
@@ -1,0 +1,1 @@
+As Trump unveils AI ‘action plan,’ where it works and where it falls short Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/As-Trump-Unveils-AI-Action-Plan-Where-It-Works-And-Where-It-Falls-Short/video-script.md
+++ b/writable/MyMI-Media/Campaigns/As-Trump-Unveils-AI-Action-Plan-Where-It-Works-And-Where-It-Falls-Short/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "As Trump unveils AI ‘action plan,’ where it works and where it falls short"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/As-Trump-Unveils-AI-Action-Plan-Where-It-Works-And-Where-It-Falls-Short/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/As-Trump-Unveils-AI-Action-Plan-Where-It-Works-And-Where-It-Falls-Short/voiceover.md
@@ -1,0 +1,1 @@
+"As Trump unveils AI ‘action plan,’ where it works and where it falls short Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Dow-And-SP500-Rising-Nasdaq-Lags-As-Stocks-Gain-Steam-Into-Final-Hour-Live/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Dow-And-SP500-Rising-Nasdaq-Lags-As-Stocks-Gain-Steam-Into-Final-Hour-Live/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Dow-And-SP500-Rising-Nasdaq-Lags-As-Stocks-Gain-Steam-Into-Final-Hour-Live/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Dow-And-SP500-Rising-Nasdaq-Lags-As-Stocks-Gain-Steam-Into-Final-Hour-Live/blog-draft.md
@@ -1,0 +1,5 @@
+# Dow and S&P 500 rising, Nasdaq lags as stocks gain steam into final hour — live
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Dow-And-SP500-Rising-Nasdaq-Lags-As-Stocks-Gain-Steam-Into-Final-Hour-Live/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Dow-And-SP500-Rising-Nasdaq-Lags-As-Stocks-Gain-Steam-Into-Final-Hour-Live/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Dow and S&P 500 rising, Nasdaq lags as stocks gain steam int
+
+Hello,
+
+Dow and S&P 500 rising, Nasdaq lags as stocks gain steam into final hour — live Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Dow-And-SP500-Rising-Nasdaq-Lags-As-Stocks-Gain-Steam-Into-Final-Hour-Live/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Dow-And-SP500-Rising-Nasdaq-Lags-As-Stocks-Gain-Steam-Into-Final-Hour-Live/social-post.md
@@ -1,0 +1,1 @@
+Dow and S&P 500 rising, Nasdaq lags as stocks gain steam into final hour — live Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Dow-And-SP500-Rising-Nasdaq-Lags-As-Stocks-Gain-Steam-Into-Final-Hour-Live/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Dow-And-SP500-Rising-Nasdaq-Lags-As-Stocks-Gain-Steam-Into-Final-Hour-Live/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Dow and S&P 500 rising, Nasdaq lags as stocks gain steam into final hour — live"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Dow-And-SP500-Rising-Nasdaq-Lags-As-Stocks-Gain-Steam-Into-Final-Hour-Live/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Dow-And-SP500-Rising-Nasdaq-Lags-As-Stocks-Gain-Steam-Into-Final-Hour-Live/voiceover.md
@@ -1,0 +1,1 @@
+"Dow and S&P 500 rising, Nasdaq lags as stocks gain steam into final hour — live Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Dow-Ends-Lower-SP500-And-Nasdaq-Notch-Fresh-Records-Despite-Teslas-Slide/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Dow-Ends-Lower-SP500-And-Nasdaq-Notch-Fresh-Records-Despite-Teslas-Slide/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Dow-Ends-Lower-SP500-And-Nasdaq-Notch-Fresh-Records-Despite-Teslas-Slide/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Ends-Lower-SP500-And-Nasdaq-Notch-Fresh-Records-Despite-Teslas-Slide/blog-draft.md
@@ -1,0 +1,5 @@
+# Dow ends lower, S&P 500 and Nasdaq notch fresh records despite Tesla’s slide
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Dow-Ends-Lower-SP500-And-Nasdaq-Notch-Fresh-Records-Despite-Teslas-Slide/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Ends-Lower-SP500-And-Nasdaq-Notch-Fresh-Records-Despite-Teslas-Slide/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Dow ends lower, S&P 500 and Nasdaq notch fresh records despi
+
+Hello,
+
+Dow ends lower, S&P 500 and Nasdaq notch fresh records despite Tesla’s slide Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Dow-Ends-Lower-SP500-And-Nasdaq-Notch-Fresh-Records-Despite-Teslas-Slide/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Ends-Lower-SP500-And-Nasdaq-Notch-Fresh-Records-Despite-Teslas-Slide/social-post.md
@@ -1,0 +1,1 @@
+Dow ends lower, S&P 500 and Nasdaq notch fresh records despite Tesla’s slide Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Dow-Ends-Lower-SP500-And-Nasdaq-Notch-Fresh-Records-Despite-Teslas-Slide/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Ends-Lower-SP500-And-Nasdaq-Notch-Fresh-Records-Despite-Teslas-Slide/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Dow ends lower, S&P 500 and Nasdaq notch fresh records despite Tesla’s slide"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Dow-Ends-Lower-SP500-And-Nasdaq-Notch-Fresh-Records-Despite-Teslas-Slide/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Ends-Lower-SP500-And-Nasdaq-Notch-Fresh-Records-Despite-Teslas-Slide/voiceover.md
@@ -1,0 +1,1 @@
+"Dow ends lower, S&P 500 and Nasdaq notch fresh records despite Tesla’s slide Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Dow-Falling-SP500-And-Nasdaq-Pare-Gains-As-Tesla-Shares-Slide-Follow-Live/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Dow-Falling-SP500-And-Nasdaq-Pare-Gains-As-Tesla-Shares-Slide-Follow-Live/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Dow-Falling-SP500-And-Nasdaq-Pare-Gains-As-Tesla-Shares-Slide-Follow-Live/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Falling-SP500-And-Nasdaq-Pare-Gains-As-Tesla-Shares-Slide-Follow-Live/blog-draft.md
@@ -1,0 +1,5 @@
+# Dow falling, S&P 500 and Nasdaq pare gains as Tesla shares slide — follow live
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Dow-Falling-SP500-And-Nasdaq-Pare-Gains-As-Tesla-Shares-Slide-Follow-Live/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Falling-SP500-And-Nasdaq-Pare-Gains-As-Tesla-Shares-Slide-Follow-Live/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Dow falling, S&P 500 and Nasdaq pare gains as Tesla shares s
+
+Hello,
+
+Dow falling, S&P 500 and Nasdaq pare gains as Tesla shares slide — follow live Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Dow-Falling-SP500-And-Nasdaq-Pare-Gains-As-Tesla-Shares-Slide-Follow-Live/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Falling-SP500-And-Nasdaq-Pare-Gains-As-Tesla-Shares-Slide-Follow-Live/social-post.md
@@ -1,0 +1,1 @@
+Dow falling, S&P 500 and Nasdaq pare gains as Tesla shares slide — follow live Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Dow-Falling-SP500-And-Nasdaq-Pare-Gains-As-Tesla-Shares-Slide-Follow-Live/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Falling-SP500-And-Nasdaq-Pare-Gains-As-Tesla-Shares-Slide-Follow-Live/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Dow falling, S&P 500 and Nasdaq pare gains as Tesla shares slide — follow live"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Dow-Falling-SP500-And-Nasdaq-Pare-Gains-As-Tesla-Shares-Slide-Follow-Live/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Falling-SP500-And-Nasdaq-Pare-Gains-As-Tesla-Shares-Slide-Follow-Live/voiceover.md
@@ -1,0 +1,1 @@
+"Dow falling, S&P 500 and Nasdaq pare gains as Tesla shares slide — follow live Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Dow-Near-Alltime-High-As-Stocks-Rise-After-Usjapan-Trade-Deal-Follow-Live/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Dow-Near-Alltime-High-As-Stocks-Rise-After-Usjapan-Trade-Deal-Follow-Live/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Dow-Near-Alltime-High-As-Stocks-Rise-After-Usjapan-Trade-Deal-Follow-Live/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Near-Alltime-High-As-Stocks-Rise-After-Usjapan-Trade-Deal-Follow-Live/blog-draft.md
@@ -1,0 +1,5 @@
+# Dow near all-time high as stocks rise after U.S.-Japan trade deal — follow live
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Dow-Near-Alltime-High-As-Stocks-Rise-After-Usjapan-Trade-Deal-Follow-Live/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Near-Alltime-High-As-Stocks-Rise-After-Usjapan-Trade-Deal-Follow-Live/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Dow near all-time high as stocks rise after U
+
+Hello,
+
+Dow near all-time high as stocks rise after U.S.-Japan trade deal — follow live Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Dow-Near-Alltime-High-As-Stocks-Rise-After-Usjapan-Trade-Deal-Follow-Live/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Near-Alltime-High-As-Stocks-Rise-After-Usjapan-Trade-Deal-Follow-Live/social-post.md
@@ -1,0 +1,1 @@
+Dow near all-time high as stocks rise after U.S.-Japan trade deal — follow live Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Dow-Near-Alltime-High-As-Stocks-Rise-After-Usjapan-Trade-Deal-Follow-Live/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Near-Alltime-High-As-Stocks-Rise-After-Usjapan-Trade-Deal-Follow-Live/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Dow near all-time high as stocks rise after U.S.-Japan trade deal — follow live"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Dow-Near-Alltime-High-As-Stocks-Rise-After-Usjapan-Trade-Deal-Follow-Live/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Near-Alltime-High-As-Stocks-Rise-After-Usjapan-Trade-Deal-Follow-Live/voiceover.md
@@ -1,0 +1,1 @@
+"Dow near all-time high as stocks rise after U.S.-Japan trade deal — follow live Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Dow-Regains-45000-Ends-Just-Shy-Of-Record-Ahead-Of-Tesla-Alphabet-Earnings/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Dow-Regains-45000-Ends-Just-Shy-Of-Record-Ahead-Of-Tesla-Alphabet-Earnings/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Dow-Regains-45000-Ends-Just-Shy-Of-Record-Ahead-Of-Tesla-Alphabet-Earnings/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Regains-45000-Ends-Just-Shy-Of-Record-Ahead-Of-Tesla-Alphabet-Earnings/blog-draft.md
@@ -1,0 +1,5 @@
+# Dow regains 45,000, ends just shy of record ahead of Tesla, Alphabet earnings
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Dow-Regains-45000-Ends-Just-Shy-Of-Record-Ahead-Of-Tesla-Alphabet-Earnings/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Regains-45000-Ends-Just-Shy-Of-Record-Ahead-Of-Tesla-Alphabet-Earnings/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Dow regains 45,000, ends just shy of record ahead of Tesla, 
+
+Hello,
+
+Dow regains 45,000, ends just shy of record ahead of Tesla, Alphabet earnings Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Dow-Regains-45000-Ends-Just-Shy-Of-Record-Ahead-Of-Tesla-Alphabet-Earnings/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Regains-45000-Ends-Just-Shy-Of-Record-Ahead-Of-Tesla-Alphabet-Earnings/social-post.md
@@ -1,0 +1,1 @@
+Dow regains 45,000, ends just shy of record ahead of Tesla, Alphabet earnings Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Dow-Regains-45000-Ends-Just-Shy-Of-Record-Ahead-Of-Tesla-Alphabet-Earnings/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Regains-45000-Ends-Just-Shy-Of-Record-Ahead-Of-Tesla-Alphabet-Earnings/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Dow regains 45,000, ends just shy of record ahead of Tesla, Alphabet earnings"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Dow-Regains-45000-Ends-Just-Shy-Of-Record-Ahead-Of-Tesla-Alphabet-Earnings/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Dow-Regains-45000-Ends-Just-Shy-Of-Record-Ahead-Of-Tesla-Alphabet-Earnings/voiceover.md
@@ -1,0 +1,1 @@
+"Dow regains 45,000, ends just shy of record ahead of Tesla, Alphabet earnings Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Heres-What-The-Postearnings-Afterhours-Whipsaw-In-Teslas-Stock-Looks-Like/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Heres-What-The-Postearnings-Afterhours-Whipsaw-In-Teslas-Stock-Looks-Like/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Heres-What-The-Postearnings-Afterhours-Whipsaw-In-Teslas-Stock-Looks-Like/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Heres-What-The-Postearnings-Afterhours-Whipsaw-In-Teslas-Stock-Looks-Like/blog-draft.md
@@ -1,0 +1,5 @@
+# Here’s what the post-earnings, after-hours whipsaw in Tesla’s stock looks like
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Heres-What-The-Postearnings-Afterhours-Whipsaw-In-Teslas-Stock-Looks-Like/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Heres-What-The-Postearnings-Afterhours-Whipsaw-In-Teslas-Stock-Looks-Like/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Here’s what the post-earnings, after-hours whipsaw in Tesla’
+
+Hello,
+
+Here’s what the post-earnings, after-hours whipsaw in Tesla’s stock looks like Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Heres-What-The-Postearnings-Afterhours-Whipsaw-In-Teslas-Stock-Looks-Like/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Heres-What-The-Postearnings-Afterhours-Whipsaw-In-Teslas-Stock-Looks-Like/social-post.md
@@ -1,0 +1,1 @@
+Here’s what the post-earnings, after-hours whipsaw in Tesla’s stock looks like Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Heres-What-The-Postearnings-Afterhours-Whipsaw-In-Teslas-Stock-Looks-Like/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Heres-What-The-Postearnings-Afterhours-Whipsaw-In-Teslas-Stock-Looks-Like/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Here’s what the post-earnings, after-hours whipsaw in Tesla’s stock looks like"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Heres-What-The-Postearnings-Afterhours-Whipsaw-In-Teslas-Stock-Looks-Like/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Heres-What-The-Postearnings-Afterhours-Whipsaw-In-Teslas-Stock-Looks-Like/voiceover.md
@@ -1,0 +1,1 @@
+"Here’s what the post-earnings, after-hours whipsaw in Tesla’s stock looks like Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Heres-Who-Is-Bearing-The-Cost-Of-Trumps-Tariffs-So-Far-This-Year/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Heres-Who-Is-Bearing-The-Cost-Of-Trumps-Tariffs-So-Far-This-Year/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Heres-Who-Is-Bearing-The-Cost-Of-Trumps-Tariffs-So-Far-This-Year/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Heres-Who-Is-Bearing-The-Cost-Of-Trumps-Tariffs-So-Far-This-Year/blog-draft.md
@@ -1,0 +1,5 @@
+# Here’s who is bearing the cost of Trump’s tariffs so far this year
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Heres-Who-Is-Bearing-The-Cost-Of-Trumps-Tariffs-So-Far-This-Year/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Heres-Who-Is-Bearing-The-Cost-Of-Trumps-Tariffs-So-Far-This-Year/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Here’s who is bearing the cost of Trump’s tariffs so far thi
+
+Hello,
+
+Here’s who is bearing the cost of Trump’s tariffs so far this year Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Heres-Who-Is-Bearing-The-Cost-Of-Trumps-Tariffs-So-Far-This-Year/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Heres-Who-Is-Bearing-The-Cost-Of-Trumps-Tariffs-So-Far-This-Year/social-post.md
@@ -1,0 +1,1 @@
+Here’s who is bearing the cost of Trump’s tariffs so far this year Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Heres-Who-Is-Bearing-The-Cost-Of-Trumps-Tariffs-So-Far-This-Year/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Heres-Who-Is-Bearing-The-Cost-Of-Trumps-Tariffs-So-Far-This-Year/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Here’s who is bearing the cost of Trump’s tariffs so far this year"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Heres-Who-Is-Bearing-The-Cost-Of-Trumps-Tariffs-So-Far-This-Year/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Heres-Who-Is-Bearing-The-Cost-Of-Trumps-Tariffs-So-Far-This-Year/voiceover.md
@@ -1,0 +1,1 @@
+"Here’s who is bearing the cost of Trump’s tariffs so far this year Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/How-Bessent-Is-Trying-To-Get-Trump-What-He-Wants-At-Fed-Without-Market-Turmoil/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/How-Bessent-Is-Trying-To-Get-Trump-What-He-Wants-At-Fed-Without-Market-Turmoil/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/How-Bessent-Is-Trying-To-Get-Trump-What-He-Wants-At-Fed-Without-Market-Turmoil/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/How-Bessent-Is-Trying-To-Get-Trump-What-He-Wants-At-Fed-Without-Market-Turmoil/blog-draft.md
@@ -1,0 +1,5 @@
+# How Bessent is trying to get Trump ‘what he wants’ at Fed without market turmoil
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/How-Bessent-Is-Trying-To-Get-Trump-What-He-Wants-At-Fed-Without-Market-Turmoil/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/How-Bessent-Is-Trying-To-Get-Trump-What-He-Wants-At-Fed-Without-Market-Turmoil/email-drip.md
@@ -1,0 +1,8 @@
+Subject: How Bessent is trying to get Trump ‘what he wants’ at Fed wi
+
+Hello,
+
+How Bessent is trying to get Trump ‘what he wants’ at Fed without market turmoil Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/How-Bessent-Is-Trying-To-Get-Trump-What-He-Wants-At-Fed-Without-Market-Turmoil/social-post.md
+++ b/writable/MyMI-Media/Campaigns/How-Bessent-Is-Trying-To-Get-Trump-What-He-Wants-At-Fed-Without-Market-Turmoil/social-post.md
@@ -1,0 +1,1 @@
+How Bessent is trying to get Trump ‘what he wants’ at Fed without market turmoil Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/How-Bessent-Is-Trying-To-Get-Trump-What-He-Wants-At-Fed-Without-Market-Turmoil/video-script.md
+++ b/writable/MyMI-Media/Campaigns/How-Bessent-Is-Trying-To-Get-Trump-What-He-Wants-At-Fed-Without-Market-Turmoil/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "How Bessent is trying to get Trump ‘what he wants’ at Fed without market turmoil"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/How-Bessent-Is-Trying-To-Get-Trump-What-He-Wants-At-Fed-Without-Market-Turmoil/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/How-Bessent-Is-Trying-To-Get-Trump-What-He-Wants-At-Fed-Without-Market-Turmoil/voiceover.md
@@ -1,0 +1,1 @@
+"How Bessent is trying to get Trump ‘what he wants’ at Fed without market turmoil Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/How-Hulk-Hogan-Helped-Transform-Pro-Wrestling-From-A-Sideshow-To-The-Main-Event/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/How-Hulk-Hogan-Helped-Transform-Pro-Wrestling-From-A-Sideshow-To-The-Main-Event/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/How-Hulk-Hogan-Helped-Transform-Pro-Wrestling-From-A-Sideshow-To-The-Main-Event/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/How-Hulk-Hogan-Helped-Transform-Pro-Wrestling-From-A-Sideshow-To-The-Main-Event/blog-draft.md
@@ -1,0 +1,5 @@
+# How Hulk Hogan helped transform pro wrestling from a sideshow to the main event
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/How-Hulk-Hogan-Helped-Transform-Pro-Wrestling-From-A-Sideshow-To-The-Main-Event/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/How-Hulk-Hogan-Helped-Transform-Pro-Wrestling-From-A-Sideshow-To-The-Main-Event/email-drip.md
@@ -1,0 +1,8 @@
+Subject: How Hulk Hogan helped transform pro wrestling from a sidesho
+
+Hello,
+
+How Hulk Hogan helped transform pro wrestling from a sideshow to the main event Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/How-Hulk-Hogan-Helped-Transform-Pro-Wrestling-From-A-Sideshow-To-The-Main-Event/social-post.md
+++ b/writable/MyMI-Media/Campaigns/How-Hulk-Hogan-Helped-Transform-Pro-Wrestling-From-A-Sideshow-To-The-Main-Event/social-post.md
@@ -1,0 +1,1 @@
+How Hulk Hogan helped transform pro wrestling from a sideshow to the main event Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/How-Hulk-Hogan-Helped-Transform-Pro-Wrestling-From-A-Sideshow-To-The-Main-Event/video-script.md
+++ b/writable/MyMI-Media/Campaigns/How-Hulk-Hogan-Helped-Transform-Pro-Wrestling-From-A-Sideshow-To-The-Main-Event/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "How Hulk Hogan helped transform pro wrestling from a sideshow to the main event"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/How-Hulk-Hogan-Helped-Transform-Pro-Wrestling-From-A-Sideshow-To-The-Main-Event/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/How-Hulk-Hogan-Helped-Transform-Pro-Wrestling-From-A-Sideshow-To-The-Main-Event/voiceover.md
@@ -1,0 +1,1 @@
+"How Hulk Hogan helped transform pro wrestling from a sideshow to the main event Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Ibms-Stock-Is-Dragging-Down-The-Dow-Why-Analysts-See-An-Opportunity-To-Buy/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Ibms-Stock-Is-Dragging-Down-The-Dow-Why-Analysts-See-An-Opportunity-To-Buy/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Ibms-Stock-Is-Dragging-Down-The-Dow-Why-Analysts-See-An-Opportunity-To-Buy/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Ibms-Stock-Is-Dragging-Down-The-Dow-Why-Analysts-See-An-Opportunity-To-Buy/blog-draft.md
@@ -1,0 +1,5 @@
+# IBM’s stock is dragging down the Dow. Why analysts see an opportunity to buy.
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Ibms-Stock-Is-Dragging-Down-The-Dow-Why-Analysts-See-An-Opportunity-To-Buy/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Ibms-Stock-Is-Dragging-Down-The-Dow-Why-Analysts-See-An-Opportunity-To-Buy/email-drip.md
@@ -1,0 +1,8 @@
+Subject: IBM’s stock is dragging down the Dow
+
+Hello,
+
+IBM’s stock is dragging down the Dow. Why analysts see an opportunity to buy. Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Ibms-Stock-Is-Dragging-Down-The-Dow-Why-Analysts-See-An-Opportunity-To-Buy/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Ibms-Stock-Is-Dragging-Down-The-Dow-Why-Analysts-See-An-Opportunity-To-Buy/social-post.md
@@ -1,0 +1,1 @@
+IBM’s stock is dragging down the Dow. Why analysts see an opportunity to buy. Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Ibms-Stock-Is-Dragging-Down-The-Dow-Why-Analysts-See-An-Opportunity-To-Buy/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Ibms-Stock-Is-Dragging-Down-The-Dow-Why-Analysts-See-An-Opportunity-To-Buy/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "IBM’s stock is dragging down the Dow. Why analysts see an opportunity to buy."
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Ibms-Stock-Is-Dragging-Down-The-Dow-Why-Analysts-See-An-Opportunity-To-Buy/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Ibms-Stock-Is-Dragging-Down-The-Dow-Why-Analysts-See-An-Opportunity-To-Buy/voiceover.md
@@ -1,0 +1,1 @@
+"IBM’s stock is dragging down the Dow. Why analysts see an opportunity to buy. Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Im-Already-Up-45000-In-About-An-Hour-Memestock-Mania-Has-Returned/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Im-Already-Up-45000-In-About-An-Hour-Memestock-Mania-Has-Returned/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Im-Already-Up-45000-In-About-An-Hour-Memestock-Mania-Has-Returned/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Im-Already-Up-45000-In-About-An-Hour-Memestock-Mania-Has-Returned/blog-draft.md
@@ -1,0 +1,5 @@
+# ‘I’m already up $45,000 in about an hour’ — meme-stock mania has returned
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Im-Already-Up-45000-In-About-An-Hour-Memestock-Mania-Has-Returned/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Im-Already-Up-45000-In-About-An-Hour-Memestock-Mania-Has-Returned/email-drip.md
@@ -1,0 +1,8 @@
+Subject: ‘I’m already up $45,000 in about an hour’ — meme-stock mania
+
+Hello,
+
+‘I’m already up $45,000 in about an hour’ — meme-stock mania has returned Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Im-Already-Up-45000-In-About-An-Hour-Memestock-Mania-Has-Returned/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Im-Already-Up-45000-In-About-An-Hour-Memestock-Mania-Has-Returned/social-post.md
@@ -1,0 +1,1 @@
+‘I’m already up $45,000 in about an hour’ — meme-stock mania has returned Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Im-Already-Up-45000-In-About-An-Hour-Memestock-Mania-Has-Returned/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Im-Already-Up-45000-In-About-An-Hour-Memestock-Mania-Has-Returned/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "‘I’m already up $45,000 in about an hour’ — meme-stock mania has returned"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Im-Already-Up-45000-In-About-An-Hour-Memestock-Mania-Has-Returned/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Im-Already-Up-45000-In-About-An-Hour-Memestock-Mania-Has-Returned/voiceover.md
@@ -1,0 +1,1 @@
+"‘I’m already up $45,000 in about an hour’ — meme-stock mania has returned Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Inflation-And-A-Historic-Cattle-Shortage-Havent-Dented-Beef-Demand-Heres-Why/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Inflation-And-A-Historic-Cattle-Shortage-Havent-Dented-Beef-Demand-Heres-Why/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Inflation-And-A-Historic-Cattle-Shortage-Havent-Dented-Beef-Demand-Heres-Why/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Inflation-And-A-Historic-Cattle-Shortage-Havent-Dented-Beef-Demand-Heres-Why/blog-draft.md
@@ -1,0 +1,5 @@
+# Inflation and a historic cattle shortage haven’t dented beef demand. Here’s why.
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Inflation-And-A-Historic-Cattle-Shortage-Havent-Dented-Beef-Demand-Heres-Why/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Inflation-And-A-Historic-Cattle-Shortage-Havent-Dented-Beef-Demand-Heres-Why/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Inflation and a historic cattle shortage haven’t dented beef
+
+Hello,
+
+Inflation and a historic cattle shortage haven’t dented beef demand. Here’s why. Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Inflation-And-A-Historic-Cattle-Shortage-Havent-Dented-Beef-Demand-Heres-Why/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Inflation-And-A-Historic-Cattle-Shortage-Havent-Dented-Beef-Demand-Heres-Why/social-post.md
@@ -1,0 +1,1 @@
+Inflation and a historic cattle shortage haven’t dented beef demand. Here’s why. Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Inflation-And-A-Historic-Cattle-Shortage-Havent-Dented-Beef-Demand-Heres-Why/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Inflation-And-A-Historic-Cattle-Shortage-Havent-Dented-Beef-Demand-Heres-Why/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Inflation and a historic cattle shortage haven’t dented beef demand. Here’s why."
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Inflation-And-A-Historic-Cattle-Shortage-Havent-Dented-Beef-Demand-Heres-Why/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Inflation-And-A-Historic-Cattle-Shortage-Havent-Dented-Beef-Demand-Heres-Why/voiceover.md
@@ -1,0 +1,1 @@
+"Inflation and a historic cattle shortage haven’t dented beef demand. Here’s why. Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Intel-Earnings-Tell-Two-Stories-As-Sales-Impress-But-Restructuring-Losses-Swell/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Intel-Earnings-Tell-Two-Stories-As-Sales-Impress-But-Restructuring-Losses-Swell/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Intel-Earnings-Tell-Two-Stories-As-Sales-Impress-But-Restructuring-Losses-Swell/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Intel-Earnings-Tell-Two-Stories-As-Sales-Impress-But-Restructuring-Losses-Swell/blog-draft.md
@@ -1,0 +1,5 @@
+# Intel earnings tell two stories, as sales impress but restructuring losses swell
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Intel-Earnings-Tell-Two-Stories-As-Sales-Impress-But-Restructuring-Losses-Swell/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Intel-Earnings-Tell-Two-Stories-As-Sales-Impress-But-Restructuring-Losses-Swell/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Intel earnings tell two stories, as sales impress but restru
+
+Hello,
+
+Intel earnings tell two stories, as sales impress but restructuring losses swell Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Intel-Earnings-Tell-Two-Stories-As-Sales-Impress-But-Restructuring-Losses-Swell/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Intel-Earnings-Tell-Two-Stories-As-Sales-Impress-But-Restructuring-Losses-Swell/social-post.md
@@ -1,0 +1,1 @@
+Intel earnings tell two stories, as sales impress but restructuring losses swell Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Intel-Earnings-Tell-Two-Stories-As-Sales-Impress-But-Restructuring-Losses-Swell/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Intel-Earnings-Tell-Two-Stories-As-Sales-Impress-But-Restructuring-Losses-Swell/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Intel earnings tell two stories, as sales impress but restructuring losses swell"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Intel-Earnings-Tell-Two-Stories-As-Sales-Impress-But-Restructuring-Losses-Swell/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Intel-Earnings-Tell-Two-Stories-As-Sales-Impress-But-Restructuring-Losses-Swell/voiceover.md
@@ -1,0 +1,1 @@
+"Intel earnings tell two stories, as sales impress but restructuring losses swell Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Newly-Built-Homes-Cheaper-Than-Previously-Owned-Ones-As-Builders-Cut-Prices/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Newly-Built-Homes-Cheaper-Than-Previously-Owned-Ones-As-Builders-Cut-Prices/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Newly-Built-Homes-Cheaper-Than-Previously-Owned-Ones-As-Builders-Cut-Prices/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Newly-Built-Homes-Cheaper-Than-Previously-Owned-Ones-As-Builders-Cut-Prices/blog-draft.md
@@ -1,0 +1,5 @@
+# Newly built homes cheaper than previously owned ones, as builders cut prices
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Newly-Built-Homes-Cheaper-Than-Previously-Owned-Ones-As-Builders-Cut-Prices/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Newly-Built-Homes-Cheaper-Than-Previously-Owned-Ones-As-Builders-Cut-Prices/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Newly built homes cheaper than previously owned ones, as bui
+
+Hello,
+
+Newly built homes cheaper than previously owned ones, as builders cut prices Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Newly-Built-Homes-Cheaper-Than-Previously-Owned-Ones-As-Builders-Cut-Prices/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Newly-Built-Homes-Cheaper-Than-Previously-Owned-Ones-As-Builders-Cut-Prices/social-post.md
@@ -1,0 +1,1 @@
+Newly built homes cheaper than previously owned ones, as builders cut prices Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Newly-Built-Homes-Cheaper-Than-Previously-Owned-Ones-As-Builders-Cut-Prices/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Newly-Built-Homes-Cheaper-Than-Previously-Owned-Ones-As-Builders-Cut-Prices/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Newly built homes cheaper than previously owned ones, as builders cut prices"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Newly-Built-Homes-Cheaper-Than-Previously-Owned-Ones-As-Builders-Cut-Prices/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Newly-Built-Homes-Cheaper-Than-Previously-Owned-Ones-As-Builders-Cut-Prices/voiceover.md
@@ -1,0 +1,1 @@
+"Newly built homes cheaper than previously owned ones, as builders cut prices Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Powell-Doesnt-Comment-On-Economy-Or-Interest-Rates-In-Brief-Remarks/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Powell-Doesnt-Comment-On-Economy-Or-Interest-Rates-In-Brief-Remarks/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Powell-Doesnt-Comment-On-Economy-Or-Interest-Rates-In-Brief-Remarks/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Powell-Doesnt-Comment-On-Economy-Or-Interest-Rates-In-Brief-Remarks/blog-draft.md
@@ -1,0 +1,5 @@
+# Powell doesn’t comment on economy or interest rates in brief remarks
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Powell-Doesnt-Comment-On-Economy-Or-Interest-Rates-In-Brief-Remarks/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Powell-Doesnt-Comment-On-Economy-Or-Interest-Rates-In-Brief-Remarks/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Powell doesn’t comment on economy or interest rates in brief
+
+Hello,
+
+Powell doesn’t comment on economy or interest rates in brief remarks Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Powell-Doesnt-Comment-On-Economy-Or-Interest-Rates-In-Brief-Remarks/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Powell-Doesnt-Comment-On-Economy-Or-Interest-Rates-In-Brief-Remarks/social-post.md
@@ -1,0 +1,1 @@
+Powell doesn’t comment on economy or interest rates in brief remarks Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Powell-Doesnt-Comment-On-Economy-Or-Interest-Rates-In-Brief-Remarks/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Powell-Doesnt-Comment-On-Economy-Or-Interest-Rates-In-Brief-Remarks/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Powell doesn’t comment on economy or interest rates in brief remarks"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Powell-Doesnt-Comment-On-Economy-Or-Interest-Rates-In-Brief-Remarks/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Powell-Doesnt-Comment-On-Economy-Or-Interest-Rates-In-Brief-Remarks/voiceover.md
@@ -1,0 +1,1 @@
+"Powell doesn’t comment on economy or interest rates in brief remarks Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Retail-Traders-Just-Cant-Quit-These-Risky-Options-As-Trading-Volume-Booms/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Retail-Traders-Just-Cant-Quit-These-Risky-Options-As-Trading-Volume-Booms/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Retail-Traders-Just-Cant-Quit-These-Risky-Options-As-Trading-Volume-Booms/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Retail-Traders-Just-Cant-Quit-These-Risky-Options-As-Trading-Volume-Booms/blog-draft.md
@@ -1,0 +1,5 @@
+# Retail traders just can’t quit these risky options, as trading volume booms
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Retail-Traders-Just-Cant-Quit-These-Risky-Options-As-Trading-Volume-Booms/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Retail-Traders-Just-Cant-Quit-These-Risky-Options-As-Trading-Volume-Booms/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Retail traders just can’t quit these risky options, as tradi
+
+Hello,
+
+Retail traders just can’t quit these risky options, as trading volume booms Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Retail-Traders-Just-Cant-Quit-These-Risky-Options-As-Trading-Volume-Booms/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Retail-Traders-Just-Cant-Quit-These-Risky-Options-As-Trading-Volume-Booms/social-post.md
@@ -1,0 +1,1 @@
+Retail traders just can’t quit these risky options, as trading volume booms Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Retail-Traders-Just-Cant-Quit-These-Risky-Options-As-Trading-Volume-Booms/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Retail-Traders-Just-Cant-Quit-These-Risky-Options-As-Trading-Volume-Booms/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Retail traders just can’t quit these risky options, as trading volume booms"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Retail-Traders-Just-Cant-Quit-These-Risky-Options-As-Trading-Volume-Booms/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Retail-Traders-Just-Cant-Quit-These-Risky-Options-As-Trading-Volume-Booms/voiceover.md
@@ -1,0 +1,1 @@
+"Retail traders just can’t quit these risky options, as trading volume booms Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/SP-Ends-At-Fresh-Record-High-Nasdaq-Falls-As-Big-Tech-Earnings-Approach/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/SP-Ends-At-Fresh-Record-High-Nasdaq-Falls-As-Big-Tech-Earnings-Approach/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/SP-Ends-At-Fresh-Record-High-Nasdaq-Falls-As-Big-Tech-Earnings-Approach/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/SP-Ends-At-Fresh-Record-High-Nasdaq-Falls-As-Big-Tech-Earnings-Approach/blog-draft.md
@@ -1,0 +1,5 @@
+# S&P ends at fresh record high, Nasdaq falls as Big Tech earnings approach
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/SP-Ends-At-Fresh-Record-High-Nasdaq-Falls-As-Big-Tech-Earnings-Approach/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/SP-Ends-At-Fresh-Record-High-Nasdaq-Falls-As-Big-Tech-Earnings-Approach/email-drip.md
@@ -1,0 +1,8 @@
+Subject: S&P ends at fresh record high, Nasdaq falls as Big Tech earn
+
+Hello,
+
+S&P ends at fresh record high, Nasdaq falls as Big Tech earnings approach Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/SP-Ends-At-Fresh-Record-High-Nasdaq-Falls-As-Big-Tech-Earnings-Approach/social-post.md
+++ b/writable/MyMI-Media/Campaigns/SP-Ends-At-Fresh-Record-High-Nasdaq-Falls-As-Big-Tech-Earnings-Approach/social-post.md
@@ -1,0 +1,1 @@
+S&P ends at fresh record high, Nasdaq falls as Big Tech earnings approach Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/SP-Ends-At-Fresh-Record-High-Nasdaq-Falls-As-Big-Tech-Earnings-Approach/video-script.md
+++ b/writable/MyMI-Media/Campaigns/SP-Ends-At-Fresh-Record-High-Nasdaq-Falls-As-Big-Tech-Earnings-Approach/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "S&P ends at fresh record high, Nasdaq falls as Big Tech earnings approach"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/SP-Ends-At-Fresh-Record-High-Nasdaq-Falls-As-Big-Tech-Earnings-Approach/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/SP-Ends-At-Fresh-Record-High-Nasdaq-Falls-As-Big-Tech-Earnings-Approach/voiceover.md
@@ -1,0 +1,1 @@
+"S&P ends at fresh record high, Nasdaq falls as Big Tech earnings approach Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Tesla-Shares-Rise-As-Earnings-Meet-Wall-Streets-Expectations-Follow-Live/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Tesla-Shares-Rise-As-Earnings-Meet-Wall-Streets-Expectations-Follow-Live/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Tesla-Shares-Rise-As-Earnings-Meet-Wall-Streets-Expectations-Follow-Live/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Tesla-Shares-Rise-As-Earnings-Meet-Wall-Streets-Expectations-Follow-Live/blog-draft.md
@@ -1,0 +1,5 @@
+# Tesla shares rise as earnings meet Wall Street’s expectations — follow live
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Tesla-Shares-Rise-As-Earnings-Meet-Wall-Streets-Expectations-Follow-Live/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Tesla-Shares-Rise-As-Earnings-Meet-Wall-Streets-Expectations-Follow-Live/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Tesla shares rise as earnings meet Wall Street’s expectation
+
+Hello,
+
+Tesla shares rise as earnings meet Wall Street’s expectations — follow live Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Tesla-Shares-Rise-As-Earnings-Meet-Wall-Streets-Expectations-Follow-Live/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Tesla-Shares-Rise-As-Earnings-Meet-Wall-Streets-Expectations-Follow-Live/social-post.md
@@ -1,0 +1,1 @@
+Tesla shares rise as earnings meet Wall Street’s expectations — follow live Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Tesla-Shares-Rise-As-Earnings-Meet-Wall-Streets-Expectations-Follow-Live/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Tesla-Shares-Rise-As-Earnings-Meet-Wall-Streets-Expectations-Follow-Live/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Tesla shares rise as earnings meet Wall Street’s expectations — follow live"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Tesla-Shares-Rise-As-Earnings-Meet-Wall-Streets-Expectations-Follow-Live/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Tesla-Shares-Rise-As-Earnings-Meet-Wall-Streets-Expectations-Follow-Live/voiceover.md
@@ -1,0 +1,1 @@
+"Tesla shares rise as earnings meet Wall Street’s expectations — follow live Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Trump-Went-To-The-Fed-To-Pressure-Powell-Did-He-Chicken-Out-Instead/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Trump-Went-To-The-Fed-To-Pressure-Powell-Did-He-Chicken-Out-Instead/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Trump-Went-To-The-Fed-To-Pressure-Powell-Did-He-Chicken-Out-Instead/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Trump-Went-To-The-Fed-To-Pressure-Powell-Did-He-Chicken-Out-Instead/blog-draft.md
@@ -1,0 +1,5 @@
+# Trump went to the Fed to pressure Powell. Did he ‘chicken out’ instead?
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Trump-Went-To-The-Fed-To-Pressure-Powell-Did-He-Chicken-Out-Instead/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Trump-Went-To-The-Fed-To-Pressure-Powell-Did-He-Chicken-Out-Instead/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Trump went to the Fed to pressure Powell
+
+Hello,
+
+Trump went to the Fed to pressure Powell. Did he ‘chicken out’ instead? Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Trump-Went-To-The-Fed-To-Pressure-Powell-Did-He-Chicken-Out-Instead/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Trump-Went-To-The-Fed-To-Pressure-Powell-Did-He-Chicken-Out-Instead/social-post.md
@@ -1,0 +1,1 @@
+Trump went to the Fed to pressure Powell. Did he ‘chicken out’ instead? Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Trump-Went-To-The-Fed-To-Pressure-Powell-Did-He-Chicken-Out-Instead/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Trump-Went-To-The-Fed-To-Pressure-Powell-Did-He-Chicken-Out-Instead/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Trump went to the Fed to pressure Powell. Did he ‘chicken out’ instead?"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Trump-Went-To-The-Fed-To-Pressure-Powell-Did-He-Chicken-Out-Instead/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Trump-Went-To-The-Fed-To-Pressure-Powell-Did-He-Chicken-Out-Instead/voiceover.md
@@ -1,0 +1,1 @@
+"Trump went to the Fed to pressure Powell. Did he ‘chicken out’ instead? Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Trumps-Trade-Deals-The-Countries-That-Have-And-Havent-Struck-Agreements/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Trumps-Trade-Deals-The-Countries-That-Have-And-Havent-Struck-Agreements/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Trumps-Trade-Deals-The-Countries-That-Have-And-Havent-Struck-Agreements/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Trumps-Trade-Deals-The-Countries-That-Have-And-Havent-Struck-Agreements/blog-draft.md
@@ -1,0 +1,5 @@
+# Trump’s trade deals: The countries that have — and haven’t — struck agreements
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Trumps-Trade-Deals-The-Countries-That-Have-And-Havent-Struck-Agreements/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Trumps-Trade-Deals-The-Countries-That-Have-And-Havent-Struck-Agreements/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Trump’s trade deals: The countries that have — and haven’t —
+
+Hello,
+
+Trump’s trade deals: The countries that have — and haven’t — struck agreements Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Trumps-Trade-Deals-The-Countries-That-Have-And-Havent-Struck-Agreements/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Trumps-Trade-Deals-The-Countries-That-Have-And-Havent-Struck-Agreements/social-post.md
@@ -1,0 +1,1 @@
+Trump’s trade deals: The countries that have — and haven’t — struck agreements Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Trumps-Trade-Deals-The-Countries-That-Have-And-Havent-Struck-Agreements/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Trumps-Trade-Deals-The-Countries-That-Have-And-Havent-Struck-Agreements/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Trump’s trade deals: The countries that have — and haven’t — struck agreements"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Trumps-Trade-Deals-The-Countries-That-Have-And-Havent-Struck-Agreements/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Trumps-Trade-Deals-The-Countries-That-Have-And-Havent-Struck-Agreements/voiceover.md
@@ -1,0 +1,1 @@
+"Trump’s trade deals: The countries that have — and haven’t — struck agreements Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Unitedhealth-Confirms-DOJ-Criminal-Probe-Two-Months-After-Dispelling-Reports/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Unitedhealth-Confirms-DOJ-Criminal-Probe-Two-Months-After-Dispelling-Reports/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Unitedhealth-Confirms-DOJ-Criminal-Probe-Two-Months-After-Dispelling-Reports/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Unitedhealth-Confirms-DOJ-Criminal-Probe-Two-Months-After-Dispelling-Reports/blog-draft.md
@@ -1,0 +1,5 @@
+# UnitedHealth confirms DOJ criminal probe, two months after dispelling reports
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Unitedhealth-Confirms-DOJ-Criminal-Probe-Two-Months-After-Dispelling-Reports/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Unitedhealth-Confirms-DOJ-Criminal-Probe-Two-Months-After-Dispelling-Reports/email-drip.md
@@ -1,0 +1,8 @@
+Subject: UnitedHealth confirms DOJ criminal probe, two months after d
+
+Hello,
+
+UnitedHealth confirms DOJ criminal probe, two months after dispelling reports Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Unitedhealth-Confirms-DOJ-Criminal-Probe-Two-Months-After-Dispelling-Reports/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Unitedhealth-Confirms-DOJ-Criminal-Probe-Two-Months-After-Dispelling-Reports/social-post.md
@@ -1,0 +1,1 @@
+UnitedHealth confirms DOJ criminal probe, two months after dispelling reports Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Unitedhealth-Confirms-DOJ-Criminal-Probe-Two-Months-After-Dispelling-Reports/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Unitedhealth-Confirms-DOJ-Criminal-Probe-Two-Months-After-Dispelling-Reports/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "UnitedHealth confirms DOJ criminal probe, two months after dispelling reports"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Unitedhealth-Confirms-DOJ-Criminal-Probe-Two-Months-After-Dispelling-Reports/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Unitedhealth-Confirms-DOJ-Criminal-Probe-Two-Months-After-Dispelling-Reports/voiceover.md
@@ -1,0 +1,1 @@
+"UnitedHealth confirms DOJ criminal probe, two months after dispelling reports Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Wall-Street-Braces-For-Deluge-Of-Treasury-Bills-In-Crucial-Test-Of-Market-Demand/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Wall-Street-Braces-For-Deluge-Of-Treasury-Bills-In-Crucial-Test-Of-Market-Demand/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Wall-Street-Braces-For-Deluge-Of-Treasury-Bills-In-Crucial-Test-Of-Market-Demand/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Wall-Street-Braces-For-Deluge-Of-Treasury-Bills-In-Crucial-Test-Of-Market-Demand/blog-draft.md
@@ -1,0 +1,5 @@
+# Wall Street braces for deluge of Treasury bills in crucial test of market demand
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Wall-Street-Braces-For-Deluge-Of-Treasury-Bills-In-Crucial-Test-Of-Market-Demand/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Wall-Street-Braces-For-Deluge-Of-Treasury-Bills-In-Crucial-Test-Of-Market-Demand/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Wall Street braces for deluge of Treasury bills in crucial t
+
+Hello,
+
+Wall Street braces for deluge of Treasury bills in crucial test of market demand Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Wall-Street-Braces-For-Deluge-Of-Treasury-Bills-In-Crucial-Test-Of-Market-Demand/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Wall-Street-Braces-For-Deluge-Of-Treasury-Bills-In-Crucial-Test-Of-Market-Demand/social-post.md
@@ -1,0 +1,1 @@
+Wall Street braces for deluge of Treasury bills in crucial test of market demand Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Wall-Street-Braces-For-Deluge-Of-Treasury-Bills-In-Crucial-Test-Of-Market-Demand/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Wall-Street-Braces-For-Deluge-Of-Treasury-Bills-In-Crucial-Test-Of-Market-Demand/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Wall Street braces for deluge of Treasury bills in crucial test of market demand"
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Wall-Street-Braces-For-Deluge-Of-Treasury-Bills-In-Crucial-Test-Of-Market-Demand/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Wall-Street-Braces-For-Deluge-Of-Treasury-Bills-In-Crucial-Test-Of-Market-Demand/voiceover.md
@@ -1,0 +1,1 @@
+"Wall Street braces for deluge of Treasury bills in crucial test of market demand Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."

--- a/writable/MyMI-Media/Campaigns/Why-Is-Ibms-Stock-Down-After-An-Earnings-Beat-Heres-One-Quibble/Storyboard/storyboard.txt
+++ b/writable/MyMI-Media/Campaigns/Why-Is-Ibms-Stock-Down-After-An-Earnings-Beat-Heres-One-Quibble/Storyboard/storyboard.txt
@@ -1,0 +1,5 @@
+
+1. Title card with headline.
+2. Show market charts reacting.
+3. Display MyMI Wallet dashboard.
+4. Close with CTA: Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Why-Is-Ibms-Stock-Down-After-An-Earnings-Beat-Heres-One-Quibble/blog-draft.md
+++ b/writable/MyMI-Media/Campaigns/Why-Is-Ibms-Stock-Down-After-An-Earnings-Beat-Heres-One-Quibble/blog-draft.md
@@ -1,0 +1,5 @@
+# Why is IBM’s stock down after an earnings beat? Here’s one quibble.
+
+This headline highlights *market volatility* and potential *investment
+opportunity*. Stay updated on **interest rates** and economic shifts. Track your
+investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Why-Is-Ibms-Stock-Down-After-An-Earnings-Beat-Heres-One-Quibble/email-drip.md
+++ b/writable/MyMI-Media/Campaigns/Why-Is-Ibms-Stock-Down-After-An-Earnings-Beat-Heres-One-Quibble/email-drip.md
@@ -1,0 +1,8 @@
+Subject: Why is IBM’s stock down after an earnings beat? Here’s one q
+
+Hello,
+
+Why is IBM’s stock down after an earnings beat? Here’s one quibble. Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.
+
+Best,
+The MyMI Wallet Team

--- a/writable/MyMI-Media/Campaigns/Why-Is-Ibms-Stock-Down-After-An-Earnings-Beat-Heres-One-Quibble/social-post.md
+++ b/writable/MyMI-Media/Campaigns/Why-Is-Ibms-Stock-Down-After-An-Earnings-Beat-Heres-One-Quibble/social-post.md
@@ -1,0 +1,1 @@
+Why is IBM’s stock down after an earnings beat? Here’s one quibble. Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools. #MyMIWallet #SmartMoneyMoves #FinanceNews2025 #MarketWatch

--- a/writable/MyMI-Media/Campaigns/Why-Is-Ibms-Stock-Down-After-An-Earnings-Beat-Heres-One-Quibble/video-script.md
+++ b/writable/MyMI-Media/Campaigns/Why-Is-Ibms-Stock-Down-After-An-Earnings-Beat-Heres-One-Quibble/video-script.md
@@ -1,0 +1,5 @@
+**Scene 1:** Text on screen with headline summary.
+**Narrator:** "Why is IBM’s stock down after an earnings beat? Here’s one quibble."
+
+**Scene 2:** Graphics illustrate market reaction and volatility.
+**Narrator:** "Use data-driven insights to spot opportunity." Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools.

--- a/writable/MyMI-Media/Campaigns/Why-Is-Ibms-Stock-Down-After-An-Earnings-Beat-Heres-One-Quibble/voiceover.md
+++ b/writable/MyMI-Media/Campaigns/Why-Is-Ibms-Stock-Down-After-An-Earnings-Beat-Heres-One-Quibble/voiceover.md
@@ -1,0 +1,1 @@
+"Why is IBM’s stock down after an earnings beat? Here’s one quibble. Keep an eye on shifting trends and Track your investments smarter with MyMI Wallet’s real-time alerts and forecasting tools."


### PR DESCRIPTION
## Summary
- generate campaign assets for 30 new financial news headlines
- include social posts, email drips, blog drafts, video scripts, voiceovers, and storyboards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882c52597e48325b5bbf8f9acb81107