### PR TITLE
Add marketing and livestream automation modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # MyMI Media Repo
+
+This repository stores marketing campaign assets and automation modules for the MyMI Wallet ecosystem.
+
+## Modules
+
+### MarketingCampaigns
+- `MarketingCampaignService.php` pulls summaries from `bf_marketing_scraper`, formats them and stores entries in `bf_marketing_campaigns`.
+- `CampaignAutomationController.php` exposes endpoints for auto scheduling, triggering livestream events and generating campaign media.
+- Views under `MarketingCampaigns/Views` render upcoming campaigns with manual launch controls.
+
+### LivestreamAutomation
+- `LiveStreamService.php` schedules weekend livestreams and builds scripts from campaign summaries.
+- `LivestreamController.php` provides routes for scheduling streams, generating scripts and serving OBS overlays.
+- Views under `LivestreamAutomation/Views` show dashboard information and simple overlay HTML snippets.
+
+SQL templates for required tables can be found in `docs/sql_templates.sql`. Example cron entries are located in `docs/CRON_EXAMPLES.md`.

--- a/app/Modules/LivestreamAutomation/LiveStreamService.php
+++ b/app/Modules/LivestreamAutomation/LiveStreamService.php
@@ -1,0 +1,42 @@
+<?php
+namespace Modules\LivestreamAutomation;
+
+use CodeIgniter\Database\ConnectionInterface;
+use DateTime;
+
+/**
+ * Service for livestream automation.
+ */
+class LiveStreamService
+{
+    /** @var ConnectionInterface */
+    protected $db;
+
+    public function __construct(ConnectionInterface $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * Schedule a weekend livestream entry.
+     */
+    public function scheduleWeekendStream(): void
+    {
+        $nextSaturday = new DateTime('next Saturday 09:00');
+        $data = ['scheduled_at' => $nextSaturday->format('Y-m-d H:i:s')];
+        $this->db->table('bf_marketing_streams')->insert($data);
+    }
+
+    /**
+     * Generate a livestream script using marketing summary content.
+     */
+    public function generateScript(int $streamId): string
+    {
+        $stream = $this->db->table('bf_marketing_streams')->where('id', $streamId)->get()->getRowArray();
+        if (!$stream) {
+            return '';
+        }
+        // Placeholder for script formatting
+        return "Intro...\n" . ($stream['summary'] ?? '') . "\nOutro...";
+    }
+}

--- a/app/Modules/LivestreamAutomation/LivestreamController.php
+++ b/app/Modules/LivestreamAutomation/LivestreamController.php
@@ -1,0 +1,42 @@
+<?php
+namespace Modules\LivestreamAutomation;
+
+use CodeIgniter\RESTful\ResourceController;
+
+class LivestreamController extends ResourceController
+{
+    /** @var LiveStreamService */
+    protected $service;
+
+    public function __construct()
+    {
+        $this->service = service('liveStreamService');
+    }
+
+    /**
+     * GET /scheduleWeekendStream
+     */
+    public function scheduleWeekendStream()
+    {
+        $this->service->scheduleWeekendStream();
+        return $this->respond(['status' => 'stream scheduled']);
+    }
+
+    /**
+     * GET /generateLiveStreamScript
+     */
+    public function generateLiveStreamScript($id)
+    {
+        $script = $this->service->generateScript((int) $id);
+        return $this->respond(['script' => $script]);
+    }
+
+    /**
+     * GET /streamOverlay/{segment}
+     */
+    public function streamOverlay($segment)
+    {
+        // Return basic HTML for OBS overlay
+        return view('LivestreamAutomation\\Views\\overlay_' . $segment);
+    }
+}

--- a/app/Modules/LivestreamAutomation/Views/Livestream/dashboard.php
+++ b/app/Modules/LivestreamAutomation/Views/Livestream/dashboard.php
@@ -1,0 +1,21 @@
+<h1>Livestream Dashboard</h1>
+<section>
+    <h2>Upcoming Stream</h2>
+    <p>Title: <?= esc($stream['title'] ?? 'N/A') ?></p>
+    <p>Summary: <?= esc($stream['summary'] ?? '') ?></p>
+    <p>Links:</p>
+    <ul>
+        <li>YouTube: <a href="<?= esc($stream['youtube_link'] ?? '#') ?>">Watch</a></li>
+        <li>Twitch: <a href="<?= esc($stream['twitch_link'] ?? '#') ?>">Watch</a></li>
+        <li>Discord: <a href="<?= esc($stream['discord_link'] ?? '#') ?>">Join</a></li>
+    </ul>
+</section>
+<section>
+    <h2>Script Preview</h2>
+    <pre><?= esc($script ?? '') ?></pre>
+</section>
+<section>
+    <h2>Stream Overlay Controls</h2>
+    <a href="/streamOverlay/headline" target="_blank">Headline Overlay</a>
+    <a href="/streamOverlay/lower_third" target="_blank">Lower Third</a>
+</section>

--- a/app/Modules/LivestreamAutomation/Views/overlay_headline.php
+++ b/app/Modules/LivestreamAutomation/Views/overlay_headline.php
@@ -1,0 +1,3 @@
+<div style="font-size:48px;color:white;background:rgba(0,0,0,0.5);padding:10px;">
+    <?= esc($headline ?? 'Stream Headline') ?>
+</div>

--- a/app/Modules/LivestreamAutomation/Views/overlay_lower_third.php
+++ b/app/Modules/LivestreamAutomation/Views/overlay_lower_third.php
@@ -1,0 +1,3 @@
+<div style="position:absolute;bottom:0;width:100%;background:rgba(0,0,0,0.7);color:white;padding:5px;">
+    <?= esc($text ?? 'Lower Third') ?>
+</div>

--- a/app/Modules/MarketingCampaigns/CampaignAutomationController.php
+++ b/app/Modules/MarketingCampaigns/CampaignAutomationController.php
@@ -1,0 +1,42 @@
+<?php
+namespace Modules\MarketingCampaigns;
+
+use CodeIgniter\RESTful\ResourceController;
+
+class CampaignAutomationController extends ResourceController
+{
+    /** @var MarketingCampaignService */
+    protected $service;
+
+    public function __construct()
+    {
+        $this->service = service('marketingCampaignService');
+    }
+
+    /**
+     * GET /autoScheduleCampaigns
+     */
+    public function autoScheduleCampaigns()
+    {
+        $this->service->pullAndFormatSummaries();
+        return $this->respond(['status' => 'scheduled']);
+    }
+
+    /**
+     * POST /triggerLiveStreamEvent
+     */
+    public function triggerLiveStreamEvent()
+    {
+        // Placeholder: link to livestream automation
+        return $this->respond(['status' => 'livestream triggered']);
+    }
+
+    /**
+     * POST /generateCampaignMedia/{id}
+     */
+    public function generateCampaignMedia($id)
+    {
+        $this->service->generateCampaignMedia((int) $id);
+        return $this->respond(['status' => 'media generated']);
+    }
+}

--- a/app/Modules/MarketingCampaigns/MarketingCampaignService.php
+++ b/app/Modules/MarketingCampaigns/MarketingCampaignService.php
@@ -1,0 +1,73 @@
+<?php
+namespace Modules\MarketingCampaigns;
+
+use CodeIgniter\Database\ConnectionInterface;
+use DateTime;
+
+/**
+ * Service class to manage marketing campaigns.
+ */
+class MarketingCampaignService
+{
+    /** @var ConnectionInterface */
+    protected $db;
+
+    public function __construct(ConnectionInterface $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * Pull summaries from bf_marketing_scraper and create campaign records.
+     */
+    public function pullAndFormatSummaries(): void
+    {
+        // Grab latest summaries
+        $summaries = $this->db->table('bf_marketing_scraper')->get()->getResultArray();
+        foreach ($summaries as $summary) {
+            $this->createCampaign($summary);
+        }
+    }
+
+    /**
+     * Create a campaign entry and schedule distribution based on the day of week.
+     */
+    public function createCampaign(array $summary): void
+    {
+        $data = [
+            'headline' => $summary['headline'] ?? '',
+            'content'  => $summary['content'] ?? '',
+            'scheduled_at' => $this->nextSchedule(),
+        ];
+        $this->db->table('bf_marketing_campaigns')->insert($data);
+    }
+
+    /**
+     * Determine when to schedule the campaign.
+     * Weekdays => daily; weekends => wrapup.
+     */
+    protected function nextSchedule(): string
+    {
+        $now = new DateTime('now');
+        $dow = (int) $now->format('N');
+        // 6 = Saturday, 7 = Sunday
+        if ($dow >= 6) {
+            return $now->modify('next Monday 09:00')->format('Y-m-d H:i:s');
+        }
+        return $now->modify('tomorrow 09:00')->format('Y-m-d H:i:s');
+    }
+
+    /**
+     * Generate campaign media assets (image/email/social posts).
+     */
+    public function generateCampaignMedia(int $campaignId): void
+    {
+        // Placeholder for integration with image generator and email templates
+        // Fetch campaign
+        $campaign = $this->db->table('bf_marketing_campaigns')->where('id', $campaignId)->get()->getRowArray();
+        if (!$campaign) {
+            return;
+        }
+        // TODO: implement actual media generation logic
+    }
+}

--- a/app/Modules/MarketingCampaigns/Views/Automation/index.php
+++ b/app/Modules/MarketingCampaigns/Views/Automation/index.php
@@ -1,0 +1,26 @@
+<h1>Upcoming Marketing Campaigns</h1>
+<table>
+    <thead>
+    <tr>
+        <th>Headline</th>
+        <th>Scheduled At</th>
+        <th>Auto Distribute</th>
+        <th>Actions</th>
+    </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($campaigns as $campaign): ?>
+        <tr>
+            <td><?= esc($campaign['headline']) ?></td>
+            <td><?= esc($campaign['scheduled_at']) ?></td>
+            <td>
+                <input type="checkbox" <?= $campaign['auto'] ? 'checked' : '' ?> />
+            </td>
+            <td>
+                <a href="/generateCampaignMedia/<?= $campaign['id'] ?>">Generate Media</a>
+                <button>Launch Now</button>
+            </td>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>

--- a/docs/CRON_EXAMPLES.md
+++ b/docs/CRON_EXAMPLES.md
@@ -1,0 +1,9 @@
+# Cron Setup Examples
+
+```
+# Friday 4 PM: generate weekend marketing wrap-up
+0 16 * * 5 /usr/bin/php /path/to/project/public/index.php autoScheduleCampaigns
+
+# Saturday 9 AM: schedule weekend livestream
+0 9 * * 6 /usr/bin/php /path/to/project/public/index.php scheduleWeekendStream
+```

--- a/docs/sql_templates.sql
+++ b/docs/sql_templates.sql
@@ -1,0 +1,11 @@
+-- Template inserts for bf_marketing_scraper
+INSERT INTO bf_marketing_scraper (headline, content, created_at)
+VALUES ('Sample headline', 'Summary content here', NOW());
+
+-- Template inserts for bf_marketing_campaigns
+INSERT INTO bf_marketing_campaigns (headline, content, scheduled_at, auto)
+VALUES ('Sample headline', 'Formatted content', NOW(), 1);
+
+-- Template inserts for bf_marketing_streams
+INSERT INTO bf_marketing_streams (title, summary, scheduled_at)
+VALUES ('Weekend Wrapup', 'Livestream summary goes here', NOW());


### PR DESCRIPTION
## Summary
- create MarketingCampaigns and LivestreamAutomation modules
- implement simple services and controllers
- add basic campaign and livestream views with overlay templates
- provide SQL templates and cron examples
- document modules in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884140d71b883258a3ab8188fbedd80